### PR TITLE
Add option to test with XVFB on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ jobs:
     - uses: neuroinformatics-unit/actions/test@main
         with:
           python-version: ${{ matrix.python-version }}
+          use-xvfb: true  # Optional, defaults to false if not specified
 ```
 
 ## Lint
@@ -131,4 +132,3 @@ git push upstream main --tags
 ```
 
 This means any actions specifying (e.g.) `v2` will automatically use the new minor version of the actions.
-

--- a/test/action.yml
+++ b/test/action.yml
@@ -11,6 +11,11 @@ inputs:
     required: false
     type: string
     default: ''
+  use-xvfb:
+    description: 'Run tests with XVFB on Linux'
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -29,8 +34,16 @@ runs:
         python -m pip install tox tox-gh-actions
 
     - name: Run tests
+      if: ${{ matrix.use-xvfb }}
       shell: bash
       run: tox ${{ inputs.tox-args }}
+
+    - name: Run tests with XVFB
+      if: ${{ !matrix.use-xvfb }}
+      # SHA corresponds to latest v1 release
+      uses: GabrielBB/xvfb-action@36f535812f1bd7e367d9fc8be6eb55502c47db26
+      with:
+        run: tox ${{ inputs.tox-args }}
 
     - name: Report coverage to codecov
       uses: codecov/codecov-action@v2


### PR DESCRIPTION
This adds a new option to the `test` action, to run tests with `xvfb` on linux. This is required for `napari` tests, as demonstrated over at https://github.com/brainglobe/brainreg-segment/pull/66

No explicit test for this functionality here, but this is tested implicitly by https://github.com/brainglobe/brainreg-segment/pull/66