### PR TITLE
Option for codecov flags in test action

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           use-xvfb: true  # Optional, defaults to false if not specified
+          codecov-flags: "my-flag"  # Optional
 ```
 
 ## Lint

--- a/test/action.yml
+++ b/test/action.yml
@@ -16,6 +16,11 @@ inputs:
     required: false
     type: boolean
     default: false
+  codecov-flags:
+    description: 'Flags to pass to codecov'
+    required: flase
+    type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -47,3 +52,4 @@ runs:
 
     - name: Report coverage to codecov
       uses: codecov/codecov-action@v3
+      flags: ${{ inputs.codecov-flags }}


### PR DESCRIPTION
In https://github.com/brainglobe/cellfinder-core/pull/124 I would like to pass custom [codecov flags](https://docs.codecov.com/docs/flags) to the codecov uploadeder. This PR adds the option to pass these to the test workflow.