### PR TITLE
flip use.xvfb conditional in action.yml

### DIFF
--- a/test/action.yml
+++ b/test/action.yml
@@ -39,12 +39,12 @@ runs:
         python -m pip install tox tox-gh-actions
 
     - name: Run tests
-      if: ${{ matrix.use-xvfb }}
+      if: ${{ !matrix.use-xvfb }}
       shell: bash
       run: tox ${{ inputs.tox-args }}
 
     - name: Run tests with XVFB
-      if: ${{ !matrix.use-xvfb }}
+      if: ${{ matrix.use-xvfb }}
       # SHA corresponds to v1.1 release
       uses: aganders3/headless-gui@7084a2048d5f367f66a40f79b19bb3ca28248544
       with:


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently, I think we are running tests _with_ XVFB when we `use.xvfb` is false, which is the default. This is confusing.
For an example see the Ubuntu 3.8 run at https://github.com/brainglobe/bg-atlasapi/actions/runs/5933797577/job/16089742691
(This may additionally slow down our tests when we don't need XVFB)

**What does this PR do?**

Ensures XVFB is run when `use.xvfb` is `true`

## References
Closes #21 

## How has this PR been tested?

Double-checking understanding with office mates and doing my best to reason logically!

## Is this a breaking change?

Yes, it _might_ break downstream workflows that need xvfb but haven't specified `use-xvfb: true` in their YAML file?

## Does this PR require an update to the documentation?

Nope.

## Checklist:

- [n/a] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality
- [n/a] The documentation has been updated to reflect any changes
- [n/a] The code has been formatted with [pre-commit](https://pre-commit.com/)
