### PR TITLE
Provide optional python version for build_sphinx_docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ build_sphinx_docs:
   runs-on: ubuntu-latest
   steps:
   - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
+    with:
+      python-version: 3.10
 ```
+The `python-version` input is optional and defaults to `3.x` (where `x` is the latest stable version of Python 3 available on the GitHub Actions platform)
 
 ## Publish Sphinx documentation
 Deploys pre-built documentation to GitHub Pages.

--- a/build_sphinx_docs/action.yml
+++ b/build_sphinx_docs/action.yml
@@ -1,6 +1,13 @@
 name: 'Build Sphinx Docs'
 description: 'Builds sphinx docs and publishes them to GitHub Pages'
 
+inputs:
+  python-version:
+    description: 'Python version'
+    required: false
+    type: string
+    default: '3.x'
+
 runs:
   using: 'composite'
   steps:
@@ -9,7 +16,7 @@ runs:
   - name: Setup Python
     uses: actions/setup-python@v4
     with:
-      python-version: '3.x'
+      python-version: ${{ inputs.python-version }}
 
   - name: Upgrade pip
     shell: bash


### PR DESCRIPTION
The `build_sphinx_docs` action always uses the latest stable Python version available on GitHub actions (now it's 3.12). However, this may cause problems for the documentation builds of some packages, for example [see here](https://github.com/neuroinformatics-unit/movement/pull/72#issuecomment-1783284546).

This PR provides an optional `python-version` input for this action, so the default `python-version: 3.x` can be overridden when necessary.

Merging this PR, followed by a new release, is required to unblock [movement PRs](https://github.com/neuroinformatics-unit/movement/pull/72).