### PR TITLE
Add workflow displatch condition to docs deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ deploy_sphinx_docs:
   needs: build_sphinx_docs
   permissions:
       contents: write
-  if: github.event_name == 'push' && github.ref_type == 'tag'
+  if: (github.event_name == 'push' && github.ref_type == 'tag') || github.event_name == 'workflow_dispatch'
   runs-on: ubuntu-latest
   steps:
   - uses: neuroinformatics-unit/actions/deploy_sphinx_docs@main

--- a/example_docs_build_and_deploy.yml
+++ b/example_docs_build_and_deploy.yml
@@ -5,6 +5,7 @@ name: Build Sphinx docs and deploy to GitHub Pages
 # docs still build successfully. The deploy job only runs when a release tag is
 # pushed to the main branch and actually pushes the generated html to the
 # gh-pages branch (which triggers a GitHub pages deployment).
+# Optionally, the deploy job can also triggered by a manual workflow dispatch.
 on:
   push:
     branches:
@@ -26,7 +27,7 @@ jobs:
     needs: build_sphinx_docs
     permissions:
       contents: write
-    if: github.event_name == 'push' && github.ref_type == 'tag'
+    if: (github.event_name == 'push' && github.ref_type == 'tag') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: neuroinformatics-unit/actions/deploy_sphinx_docs@main


### PR DESCRIPTION
This just modifies the example workflows, not the action itself.
Each repo owner has to decide whether to allow manual dispatch for deployment.