### PR TITLE
Bump action versions in upload_pypi

### DIFF
--- a/example_test_and_deploy.yml
+++ b/example_test_and_deploy.yml
@@ -54,7 +54,7 @@ jobs:
       with:
         name: artifact
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.8.0
+    - uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         user: __token__
         password: ${{ secrets.TWINE_API_KEY }}

--- a/example_test_and_deploy.yml
+++ b/example_test_and_deploy.yml
@@ -50,11 +50,11 @@ jobs:
     needs: [build_sdist_wheels]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.5.0
+    - uses: pypa/gh-action-pypi-publish@v1.8.0
       with:
         user: __token__
         password: ${{ secrets.TWINE_API_KEY }}

--- a/upload_pypi/action.yml
+++ b/upload_pypi/action.yml
@@ -10,11 +10,11 @@ secrets:
 runs:
   using: "composite"
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.4.2
+    - uses: pypa/gh-action-pypi-publish@v1.8
       with:
         user: __token__
         password: ${{ secrets.twine-api-key }}

--- a/upload_pypi/action.yml
+++ b/upload_pypi/action.yml
@@ -14,7 +14,7 @@ runs:
       with:
         name: artifact
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.8
+    - uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         user: __token__
         password: ${{ secrets.twine-api-key }}


### PR DESCRIPTION
No idea why `dependabot` didn't update `actions/download-artifact` from v3 to v4, but it's critical that we do it, because it has to match the major version of `actions/upload-artifact`, which was bumped to v4` by the bot.


Bumping our versions through depandabot exposed a few other minor issues in our actions setup, related to the pypi upload action, see:
- https://github.com/brainglobe/brainglobe-template-builder/pull/11
- https://github.com/brainglobe/brainglobe-template-builder/pull/12

for our debugging experiments.

In this PR we also fix the pypi upload action to use the latest version (pinning to 1.8.11)