### PR TITLE
Update pypi publishing action to latest patch

### DIFF
--- a/example_test_and_deploy.yml
+++ b/example_test_and_deploy.yml
@@ -54,7 +54,7 @@ jobs:
       with:
         name: artifact
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.8.0
+    - uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         user: __token__
         password: ${{ secrets.TWINE_API_KEY }}

--- a/upload_pypi/action.yml
+++ b/upload_pypi/action.yml
@@ -14,7 +14,7 @@ runs:
       with:
         name: artifact
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.8
+    - uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         user: __token__
         password: ${{ secrets.twine-api-key }}


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Bumping our versions through depandabot exposed a few minor issues in our actions setup
See
- https://github.com/brainglobe/brainglobe-template-builder/pull/11
- https://github.com/brainglobe/brainglobe-template-builder/pull/12
for our debugging experiments.

**What does this PR do?**
Fix the pypi upload action to use the latest version and update the example workflow to actually use the upload action

## References


## How has this PR been tested?

See above PRs to brainglobe-template-builder which served as a test.

## Is this a breaking change?

May cause failures in repos using our actions (but hopefully not). This was announced on NIU slack and BrainGlobe zulip.

## Does this PR require an update to the documentation?

Nope

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
