### PR TITLE
Make upload_pypi action easier to reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,18 +76,13 @@ Upload distributions to PyPI.
 Example usage:
 ```yaml
 upload_all:
-name: Publish build distributions
-needs: [build_sdist_wheels]
-runs-on: ubuntu-latest
-steps:
-- uses: actions/download-artifact@v3
-with:
-name: artifact
-path: dist
-- uses: pypa/gh-action-pypi-publish@v1.5.0
-with:
-user: __token__
-password: ${{ secrets.TWINE_API_KEY }}
+    name: Publish build distributions
+    needs: [build_sdist_wheels]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: neuroinformatics-unit/actions/upload_pypi@main
+      with:
+        secret_name: TWINE_API_KEY  # Or whatever you called your secret
 ```
 
 ## Build Sphinx documentation

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ upload_all:
     steps:
     - uses: neuroinformatics-unit/actions/upload_pypi@main
       secrets:
-          pypi-api-key: ${{ secrets.MY_PYPI_KEY }}  # Replace MY_PYPI_KEY with the name of your secret
+        # Replace MY_PYPI_KEY with the name of the repository secret containing the PyPI API key
+        pypi-api-key: ${{ secrets.MY_PYPI_KEY }}
 ```
 
 ## Build Sphinx documentation

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ upload_all:
     runs-on: ubuntu-latest
     steps:
     - uses: neuroinformatics-unit/actions/upload_pypi@main
-      with:
-        secret_name: TWINE_API_KEY  # Or whatever you called your secret
+      secrets:
+          pypi-api-key: ${{ secrets.MY_PYPI_KEY }}  # Replace MY_PYPI_KEY with the name of your secret
 ```
 
 ## Build Sphinx documentation

--- a/example_test_and_deploy.yml
+++ b/example_test_and_deploy.yml
@@ -50,11 +50,6 @@ jobs:
     needs: [build_sdist_wheels]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: neuroinformatics-unit/actions/upload_pypi@main
       with:
-        name: artifact
-        path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.8.11
-      with:
-        user: __token__
-        password: ${{ secrets.TWINE_API_KEY }}
+        secret_name: TWINE_API_KEY  # Or whatever you called your secret

--- a/example_test_and_deploy.yml
+++ b/example_test_and_deploy.yml
@@ -51,5 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: neuroinformatics-unit/actions/upload_pypi@main
-      with:
-        secret_name: TWINE_API_KEY  # Or whatever you called your secret
+      secrets:
+        # Replace MY_PYPI_KEY with the name of the repository secret containing the PyPI API key
+        pypi-api-key: ${{ secrets.MY_PYPI_KEY }}

--- a/upload_pypi/README.md
+++ b/upload_pypi/README.md
@@ -1,8 +1,13 @@
-# Upload packages to PyPi
+# Upload packages to PyPI
 
 This action uploads pre-built Python packages to the Python Packaging Index
-(PyPi). Packages must have been uploaded as an artefact in the `dist/`
+(PyPI). Packages must have been uploaded as an artefact in the `dist/`
 directory in a previous step or job in the same GitHub actions workflow.
 
-Your PyPi API key must be specified as the `twine-api-key` secret to the
-composite action.
+For this action to work, you must have a PyPI API token stored as a secret in your repository and you need to pass the name of the secret to the action using the `secret_name` input. For example, if the secret's name is `TWINE_API_KEY` (the value would be the PyPI API token):
+
+```yaml
+- uses: neuroinformatics-unit/actions/upload_pypi@main
+    with:
+        secret_name: TWINE_API_KEY
+```

--- a/upload_pypi/README.md
+++ b/upload_pypi/README.md
@@ -4,10 +4,12 @@ This action uploads pre-built Python packages to the Python Packaging Index
 (PyPI). Packages must have been uploaded as an artefact in the `dist/`
 directory in a previous step or job in the same GitHub actions workflow.
 
-For this action to work, you must have a PyPI API token stored as a secret in your repository and you need to pass the name of the secret to the action using the `secret_name` input. For example, if the secret's name is `TWINE_API_KEY` (the value would be the PyPI API token):
+For this action to work, you must have a PyPI API token stored as a repository secret and you need to pass the name of that secret to the `pypi-api-key`, under the `secrets` context. For example, if your secret's name is `MY_PYPI_KEY`:
 
 ```yaml
 - uses: neuroinformatics-unit/actions/upload_pypi@main
-    with:
-        secret_name: TWINE_API_KEY
+    secrets:
+        pypi-api-key: ${{ secrets.MY_PYPI_KEY }}
 ```
+
+This way your secret will be passed from the caller workflow to the reusable action, without exposing it in the action's code.

--- a/upload_pypi/action.yml
+++ b/upload_pypi/action.yml
@@ -1,5 +1,5 @@
 name: 'Upload packages to PyPI'
-description: 'Upload built packages to the Python Packaging Index (PyPI).'
+description: 'Upload built packages to the Python Package Index (PyPI).'
 
 on:
   workflow_call:

--- a/upload_pypi/action.yml
+++ b/upload_pypi/action.yml
@@ -1,15 +1,19 @@
 name: 'Upload packages to PyPi'
 description: 'Upload built packages to the Python Packaging Index (PyPi).'
 
-secrets:
-  twine-api-key:
-    description: 'Twine API key'
-    required: true
-    type: string
+on:
+  workflow_call:
+    inputs:
+      secret_name:
+        description: 'Name of the secret containing the PyPI API key'
+        required: true
+        type: string
 
 runs:
   using: "composite"
-    steps:
+  steps:
+    - name: Set up API Key
+      run: echo "PYPI_API_KEY=${{ secrets[inputs.secret_name] }}" >> $GITHUB_ENV
     - uses: actions/download-artifact@v4
       with:
         name: artifact
@@ -17,4 +21,4 @@ runs:
     - uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         user: __token__
-        password: ${{ secrets.twine-api-key }}
+        password: ${{ env.PYPI_API_KEY }}

--- a/upload_pypi/action.yml
+++ b/upload_pypi/action.yml
@@ -1,19 +1,16 @@
-name: 'Upload packages to PyPi'
-description: 'Upload built packages to the Python Packaging Index (PyPi).'
+name: 'Upload packages to PyPI'
+description: 'Upload built packages to the Python Packaging Index (PyPI).'
 
 on:
   workflow_call:
-    inputs:
-      secret_name:
-        description: 'Name of the secret containing the PyPI API key'
+    secrets:
+      pypi-api-key:
+        description: 'API key for publishing to PyPI'
         required: true
-        type: string
 
 runs:
   using: "composite"
   steps:
-    - name: Set up API Key
-      run: echo "PYPI_API_KEY=${{ secrets[inputs.secret_name] }}" >> $GITHUB_ENV
     - uses: actions/download-artifact@v4
       with:
         name: artifact
@@ -21,4 +18,4 @@ runs:
     - uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         user: __token__
-        password: ${{ env.PYPI_API_KEY }}
+        password: ${{ secrets.pypi-api-key }}


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We have an `upload_pypi` action that no one currently uses. I've updated the action and the docs / example workflow in a way that makes it clear how to pass the PyPI API key from repository secrets to the caller workflow and from there to the reusable `upload_pypi` action.

## How has this PR been tested?

Not yet. After merging this, I will try to use this action from this repository's main branch, and if that succeeds, I will make a new release.

## Is this a breaking change?

Not really, because no one was using this action.

## Does this PR require an update to the documentation?

The example workflows and the instructions in README have been updated accordingly.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
