### PR TITLE
Document updated upload_pypi action

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ upload_all:
     runs-on: ubuntu-latest
     steps:
     - uses: neuroinformatics-unit/actions/upload_pypi@main
-      secrets:
+      with:
         # Replace MY_PYPI_KEY with the name of the repository secret containing the PyPI API key
-        pypi-api-key: ${{ secrets.MY_PYPI_KEY }}
+        secret-pypi-key: ${{ secrets.MY_PYPI_KEY }}
 ```
 
 ## Build Sphinx documentation

--- a/example_test_and_deploy.yml
+++ b/example_test_and_deploy.yml
@@ -51,6 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: neuroinformatics-unit/actions/upload_pypi@main
-      secrets:
+      with:
         # Replace MY_PYPI_KEY with the name of the repository secret containing the PyPI API key
-        pypi-api-key: ${{ secrets.MY_PYPI_KEY }}
+        secret-pypi-key: ${{ secrets.MY_PYPI_KEY }}

--- a/upload_pypi/README.md
+++ b/upload_pypi/README.md
@@ -4,12 +4,11 @@ This action uploads pre-built Python packages to the Python Packaging Index
 (PyPI). Packages must have been uploaded as an artefact in the `dist/`
 directory in a previous step or job in the same GitHub actions workflow.
 
-For this action to work, you must have a PyPI API token stored as a repository secret and you need to pass the name of that secret to the `pypi-api-key`, under the `secrets` context. For example, if your secret's name is `MY_PYPI_KEY`:
+For this action to work, you must have a PyPI API token stored as a repository
+secret and that must be passed as an input to the action.
 
 ```yaml
 - uses: neuroinformatics-unit/actions/upload_pypi@main
-    secrets:
-        pypi-api-key: ${{ secrets.MY_PYPI_KEY }}
+      with:
+        secret-pypi-key: ${{ secrets.MY_PYPI_KEY }}
 ```
-
-This way your secret will be passed from the caller workflow to the reusable action, without exposing it in the action's code.


### PR DESCRIPTION
The upload_pypi action has been updated to accept the PyPI upload key as a secret input.
This functionality is now documented, with examples of how to use this action in other repos' workflows.
