### PR TITLE
Add required codecov token

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -5,4 +5,12 @@ This action:
 - Takes the python version as input
 - Installs tox
 - Uses tox to run tests from a tox.ini file
-- Reports coverage to codecov.io
+- Reports coverage to [codecov.io](https://about.codecov.io/)
+
+With `v4` of the Codecov GitHub Action, tokenless uploads are not supported. You must [provide an upload token](https://docs.codecov.com/docs/frequently-asked-questions#section-where-is-the-repository-upload-token-found-) from [codecov.io](https://about.codecov.io/) stored as a repository secret and that must be passed as an input to the action.
+
+```yaml
+- uses: neuroinformatics-unit/actions/test@main
+      with:
+        secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
+```

--- a/test/action.yml
+++ b/test/action.yml
@@ -54,6 +54,7 @@ runs:
         run: tox ${{ inputs.tox-args }}
 
     - name: Issue deprecation warning for tokenless codecov
+      shell: bash
       run: |
         if [[ -z "${{ inputs.secret-codecov-token }}" ]]; then
           echo '::warning::secret-codecov-token is not set. This will be required in the future.'\

--- a/test/action.yml
+++ b/test/action.yml
@@ -53,6 +53,13 @@ runs:
       with:
         run: tox ${{ inputs.tox-args }}
 
+    - name: Issue deprecation warning for tokenless codecov
+      run: |
+        if [[ -z "${{ inputs.secret-codecov-token }}" ]]; then
+          echo '::warning::secret-codecov-token is not set. This will be required in the future.'\
+          'See https://docs.codecov.com/docs/quick-start#step-2-get-the-repository-upload-token on how to get a token.'
+        fi
+
     - name: Report coverage to codecov
       uses: codecov/codecov-action@v4
       with:

--- a/test/action.yml
+++ b/test/action.yml
@@ -23,7 +23,7 @@ inputs:
     default: ''
   secret-codecov-token:
     description: 'Codecov token to upload coverage reports'
-    required: true
+    required: false
 
 runs:
   using: "composite"

--- a/test/action.yml
+++ b/test/action.yml
@@ -21,6 +21,9 @@ inputs:
     required: false
     type: string
     default: ''
+  secret-codecov-token:
+    description: 'Codecov token to upload coverage reports'
+    required: true
 
 runs:
   using: "composite"
@@ -54,3 +57,4 @@ runs:
       uses: codecov/codecov-action@v4
       with:
         flags: ${{ inputs.codecov-flags }}
+        token: ${{ inputs.secret-codecov-token }}


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR closes #45. 

**What does this PR do?**
This PR adds the required Codecov token for uploading coverage reports. For now, the token is optional but this will be required in the future. It also issues a deprecation warning if no token is set. 

## References
#45

## How has this PR been tested?
This PR has been tested both [with](https://github.com/lochhh/tdd-toy-example/actions/runs/8138915551) and [without the upload token](https://github.com/lochhh/tdd-toy-example/actions/runs/8138699947) in a toy repository. 

## Is this a breaking change?
This PR deprecates tokenless codecov uploads. In the future, the token will be required, rather than optional, i.e. repositories using the `test` action are expected to have a Codecov token set inside _Settings > Secrets_ as `CODECOV_TOKEN` . If not, you can [get an upload token](https://docs.codecov.io/docs/frequently-asked-questions#section-where-is-the-repository-upload-token-found-) for your specific repo on [codecov.io](https://www.codecov.io/). Keep in mind that secrets are not available to forks of repositories.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
