### PR TITLE
Use `make` in build sphinx docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ build_sphinx_docs:
     with:
       python-version: 3.10
       check-links: false
+      use-make: false
 ```
 The `python-version` input is optional and defaults to `3.x` (where `x` is the latest stable version of Python 3 available on the GitHub Actions platform)
 
 The `check-links` input is also optional and defaults to `true`. If set to `true`, the action will use the Sphinx linkcheck builder to check the integrity of all **external** links.
+
+The `use-make` input is optional and defaults to `false`. If set to `true`, the action will use the `make` utility with a custom `docs/Makefile` to build the pages from `SOURCEDIR` to `BUILDDIR` as defined in the Makefile. If set to `false`, the action will use `sphinx-build` to build the pages from `docs/source` to `docs/build`.
 
 ## Publish Sphinx documentation
 Deploys pre-built documentation to GitHub Pages.
@@ -122,7 +125,9 @@ deploy_sphinx_docs:
   - uses: neuroinformatics-unit/actions/deploy_sphinx_docs@main
     with:
       secret_input: ${{ secrets.GITHUB_TOKEN }}
+      use-make: false
 ```
+The `use-make` input is optional and defaults to `false`. If set to `true`, the action will assume that the Sphinx documentation is built using `make` and will use the `./docs/build/html` directory as the publish directory. If set to `false`, it will use the `./docs/build/` directory instead. 
 
 ## Full Workflows
 * An example workflow, including linting, testing and release can be found at [example_test_and_deploy.yml](./example_test_and_deploy.yml).

--- a/build_sphinx_docs/README.md
+++ b/build_sphinx_docs/README.md
@@ -9,8 +9,9 @@ The various steps include:
 * pip installing build dependencies (themes, build tools, etc.) from `docs/requirements.txt`
 * checking that external links in the documentation are not broken 
   * optional, defaults to `true` (i.e. links are checked), see the [warning](#warning) below for more information
-* building the html pages based on `docs/Makefile` using the `make` utility 
-  * pages are built from `SOURCEDIR` (should contain Sphinx source files) to `BUILDDIR` defined in the Makefile
+* building the html pages in one of two ways, by setting the `use-make` input (default: `false`)
+  * (default) using `sphinx-build` to build the pages from `docs/source` (should contain Sphinx source files) to `docs/build`
+  * (`use-make: true`) using the `make` utility with a custom `docs/Makefile` to build the pages from `SOURCEDIR` to `BUILDDIR` as defined in the Makefile
 * uploading the built html pages as an artifact named `docs-build`, for use in other actions
 
 It can be run upon all pull requests, to ensure that documentation still builds.
@@ -20,6 +21,10 @@ It does not publish or deploy the documentation in any way (for that, check the 
 ## Warning
 
 You can debug the linkcheck step by running it locally:
+```bash
+sphinx-build docs/source docs/build -b linkcheck
+```
+or, if you have `docs/Makefile`:
 ```bash
 cd docs && make linkcheck
 ```

--- a/build_sphinx_docs/README.md
+++ b/build_sphinx_docs/README.md
@@ -7,9 +7,10 @@ The various steps include:
   * the version can be specified via the `python-version` input, and defaults to `3.x`
 * installing pip and setting up pip cache
 * pip installing build dependencies (themes, build tools, etc.) from `docs/requirements.txt`
-* Checking that external links in the documentation are not broken 
+* checking that external links in the documentation are not broken 
   * optional, defaults to `true` (i.e. links are checked), see the [warning](#warning) below for more information
-* building the html pages from `docs/source` (should contain Sphinx source files) to `docs/build`
+* building the html pages based on `docs/Makefile` using the `make` utility 
+  * pages are built from `SOURCEDIR` (should contain Sphinx source files) to `BUILDDIR` defined in the Makefile
 * uploading the built html pages as an artifact named `docs-build`, for use in other actions
 
 It can be run upon all pull requests, to ensure that documentation still builds.
@@ -20,7 +21,7 @@ It does not publish or deploy the documentation in any way (for that, check the 
 
 You can debug the linkcheck step by running it locally:
 ```bash
-sphinx-build docs/source docs/build -b linkcheck
+make linkcheck
 ```
 If the linkcheck step produces "false positives" for your project (i.e. marking valid links as broken), you have two options:
 

--- a/build_sphinx_docs/README.md
+++ b/build_sphinx_docs/README.md
@@ -21,7 +21,7 @@ It does not publish or deploy the documentation in any way (for that, check the 
 
 You can debug the linkcheck step by running it locally:
 ```bash
-make linkcheck
+cd docs && make linkcheck
 ```
 If the linkcheck step produces "false positives" for your project (i.e. marking valid links as broken), you have two options:
 

--- a/build_sphinx_docs/action.yml
+++ b/build_sphinx_docs/action.yml
@@ -12,6 +12,11 @@ inputs:
     required: false
     type: boolean
     default: true
+  use-make:
+    description: 'Use `make` with linkcheck and building html'
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: 'composite'
@@ -49,11 +54,22 @@ runs:
   - name: Check links
     if: ${{ inputs.check-links == 'true' }}
     shell: bash
-    run: cd docs && make linkcheck
+    run: | 
+      if [ ${{ inputs.use-make }} == 'true' ]; then
+        cd docs && make linkcheck
+      else
+        sphinx-build docs/source docs/build -b linkcheck
+      fi
+
   # needs to have sphinx.ext.githubpages in conf.py extensions list
   - name: Building documentation
     shell: bash
-    run: cd docs && make html
+    run: | 
+      if [ ${{ inputs.use-make }} == 'true' ]; then
+        cd docs && make html
+      else
+        sphinx-build docs/source docs/build -b html
+      fi
 
   - name: Upload the content for deployment
     uses: actions/upload-artifact@v4

--- a/build_sphinx_docs/action.yml
+++ b/build_sphinx_docs/action.yml
@@ -49,12 +49,11 @@ runs:
   - name: Check links
     if: ${{ inputs.check-links == 'true' }}
     shell: bash
-    run: sphinx-build docs/source docs/build -b linkcheck
-
+    run: cd docs && make linkcheck
   # needs to have sphinx.ext.githubpages in conf.py extensions list
   - name: Building documentation
     shell: bash
-    run: sphinx-build docs/source docs/build -b html
+    run: cd docs && make html
 
   - name: Upload the content for deployment
     uses: actions/upload-artifact@v4

--- a/deploy_sphinx_docs/README.md
+++ b/deploy_sphinx_docs/README.md
@@ -6,3 +6,8 @@ The various steps include:
 * Removing any previous builds, if present in `docs/build`
 * downloading the built html pages (artifact named `docs-build`) into the `docs/build` folder (see the [Build Sphinx Docs action](../build_sphinx_docs/README.md))
 * deploying the`html` pages to the `gh-pages` branch. This step uses [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages).
+
+The `use-make` input is optional and defaults to `false`. 
+As this input helps to identify the location of the built documentation for deployment, it should match the `use-make` value specified in the [Build Sphinx Docs action](../build_sphinx_docs/README.md).
+If set to `true`, it is assumed that the documentation is built using `make` and the `./docs/build/html` directory will be used as the publish directory. 
+If set to `false`, the `./docs/build/` directory will be used instead.

--- a/deploy_sphinx_docs/action.yml
+++ b/deploy_sphinx_docs/action.yml
@@ -5,6 +5,13 @@ inputs:
   secret_input:
     description: 'The secret input for the GitHub token'
     required: true
+  use-make:
+    description: |
+      Specify whether `make` is used in the `build_sphinx_docs` action,
+      so that the correct publish directory is used
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: 'composite'
@@ -28,4 +35,4 @@ runs:
     uses: peaceiris/actions-gh-pages@v4
     with:
       github_token: ${{ env.GITHUB_TOKEN }}
-      publish_dir: ./docs/build
+      publish_dir: ${{ inputs.use-make == 'true' && './docs/build/html' || './docs/build/' }}


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
This PR adds the optional `use-make` input to the `build_sphinx_docs` action to allow docs to be built using the `make` utility, such that we can use, e.g.:
  - `make html` instead of  `sphinx-build source build`
  - `make clean html` instead of `rm -rf build && sphinx-build source build`
  - `make linkcheck` instead of `sphinx-build source build -b linkcheck` 

This will also allow custom build targets in the `make` file, e.g., [to automate the API index page generation](https://github.com/neuroinformatics-unit/movement/pull/234). 

Since `make` places the built html pages in `docs/build/html/`, whereas the default `sphinx-build` places these in `docs/build` (as [pointed out](https://github.com/neuroinformatics-unit/actions/pull/58#issuecomment-2221200229) by @niksirbi), the optional `use-make` input is also added to the `deploy_sphinx_docs` action to help identify the location of the built documentation for deployment. 

To ensure all current repositories using these actions remain unaffected, `use-make` is set to `false` by default, i.e. they will continue to use `sphinx-build` and project maintainers can opt-in as needed. 

## How has this PR been tested?
This has been tested 
- locally in the aforementioned [`movement` PR](https://github.com/neuroinformatics-unit/movement/pull/234).
- remotely in a [forked `movement` repository](https://github.com/lochhh/movement); the auto-generated API pages can be found [here](https://lochhh.github.io/movement/api_index.html)
  
## Does this PR require an update to the documentation?
Updated description in all `README.md`s

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
