### PR TITLE
Treat warnings as errors in doc building action

### DIFF
--- a/build_sphinx_docs/action.yml
+++ b/build_sphinx_docs/action.yml
@@ -68,7 +68,7 @@ runs:
       if [ ${{ inputs.use-make }} == 'true' ]; then
         cd docs && make html
       else
-        sphinx-build docs/source docs/build -b html
+        sphinx-build docs/source docs/build -b html -W --keep-going
       fi
 
   - name: Upload the content for deployment


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
On issue [#252](https://github.com/neuroinformatics-unit/movement/issues/252), @lochhh pointed out that `sphinx-build` returns a successful exit code (0) even if it encountered errors.

This can be quite annoying: in practice it means we need to remember to manually check the logs of the action (or locally), to confirm that there were no errors, even if the action shows a pass. 

The [simplest workaround](https://github.com/sphinx-doc/sphinx/issues/10397) seems to add the flags `-W --keep-going` so that `sphinx-build` runs to completion, treats warnings as errors, and returns a non-zero exit code if there are errors or warnings.

**What does this PR do?**
Adds the flags `-W --keep-going` to the `sphinx-build` in the doc building workflow file.

## References

In `movement` we build the docs in CI using `make`, and have a PR to add the `-W --keep-going` to the makefile:
- issue [#252](https://github.com/neuroinformatics-unit/movement/issues/252).
- PR [#256](https://github.com/neuroinformatics-unit/movement/pull/256), where we added this flags to the Makefile.

## How has this PR been tested?

I have checked that the syntax of the `sphinx-build` command works locally as expected. I am not sure how to test this further.

## Is this a breaking change?

I think no.

## Does this PR require an update to the documentation?

AFAIK this is not documented beyond the workflow file itself.

## Checklist:

- [ n/a ] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
