### PR TITLE
Add fetch tags as an input

### DIFF
--- a/build_sphinx_docs/action.yml
+++ b/build_sphinx_docs/action.yml
@@ -7,6 +7,11 @@ inputs:
     required: false
     type: string
     default: '3.x'
+  fetch-tags:
+    description: 'Fetch tags'
+    required: false
+    type: boolean
+    default: false
   check-links:
     description: 'Check links'
     required: false
@@ -22,6 +27,11 @@ runs:
   using: 'composite'
   steps:
   - uses: actions/checkout@v4
+    with:
+      fetch-depth: ${{ inputs.fetch-tags == 'false' && 1 || 0 }}  
+      # If 0, fetch all history for all branches and tags. Default is 1 (only the latest commit).
+      # The value after && needs to be truthy, hence the "inverted" conditional.
+      fetch-tags: ${{ inputs.fetch-tags == 'true' }}
 
   - name: Setup Python
     uses: actions/setup-python@v5


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently the checkout step in the build docs action does not retrieve the full history of branches and tags - it just takes the latest commit. If the latest commit does not have a tag, the build action retrieves the wrong version number for the docs.

See for example these [deployment action logs](https://github.com/neuroinformatics-unit/ethology/actions/runs/14109168642/job/39523029170#step:2:504): we can see that the installed version of `ethology` points to the correct commit in main (`4bd192`) but the stated version is off. It says `ethology-0.1.dev1+g4bd1922`, rather than the expected `ethology-0.0.2.dev22+g4bd192`.

In [the online docs](https://ethology.neuroinformatics.dev/) the version stated is also off.

**What does this PR do?**
Adds `fetch-tags` as an input, and sets it to False by default.

## References

- ethology [PR 75](https://github.com/neuroinformatics-unit/ethology/pull/75)
- [Zulip discussion: ](https://neuroinformatics.zulipchat.com/#narrow/channel/483869-Ethology/topic/Retrieving.20Version.20in.20Docs.20Config/near/510611724)[#Ethology > Retrieving Version in Docs Config @ 💬](https://neuroinformatics.zulipchat.com/#narrow/channel/483869-Ethology/topic/Retrieving.20Version.20in.20Docs.20Config/near/510611724)

## How has this PR been tested?

In [this draft PR](https://github.com/neuroinformatics-unit/ethology/pull/76), @richarddushime replaced our use of the composite action with an equivalent build-docs action, that includes the tag fetching step. The [logs](https://github.com/neuroinformatics-unit/ethology/actions/runs/14248101415/job/39934051904?pr=76#step:6:12) state the correct version for ethology.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ n.a ] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ n.a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
