### PR TITLE
Adapt sphinx deployment job for compatibility with artifact.ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The `check-links` input is also optional and defaults to `true`. If set to `true
 
 The `use-make` input is optional and defaults to `false`. If set to `true`, the action will use the `make` utility with a custom `docs/Makefile` to build the pages from `SOURCEDIR` to `BUILDDIR` as defined in the Makefile. If set to `false`, the action will use `sphinx-build` to build the pages from `docs/source` to `docs/build`.
 
+The `use-artifactci` input is optional and defaults to `false`. If set to `true`, the action will use [artifact.ci](https://www.artifact.ci/) to upload the built documentation as an artifact. This is useful for pre-viewing the docs on pull requests, but requires the `artifact.ci` app to be enabled for the target repository.
+
 ## Publish Sphinx documentation
 Deploys pre-built documentation to GitHub Pages.
 
@@ -112,6 +114,8 @@ deploy_sphinx_docs:
       use-make: false
 ```
 The `use-make` input is optional and defaults to `false`. If set to `true`, the action will assume that the Sphinx documentation is built using `make` and will use the `./docs/build/html` directory as the publish directory. If set to `false`, it will use the `./docs/build/` directory instead. 
+
+The `use-artifactci` input is optional and defaults to `false`. If set to `true`, the action will assume that the artifact was uploaded using [artifact.ci](https://www.artifact.ci/) and enable an additional step to move the contents of the artifact to the correct publish directory.
 
 ## Full Workflows
 * An example workflow, including linting, testing and release can be found at [example_test_and_deploy.yml](./example_test_and_deploy.yml).

--- a/build_sphinx_docs/README.md
+++ b/build_sphinx_docs/README.md
@@ -13,7 +13,7 @@ The various steps include:
   * (default) using `sphinx-build` to build the pages from `docs/source` (should contain Sphinx source files) to `docs/build`
   * (`use-make: true`) using the `make` utility with a custom `docs/Makefile` to build the pages from `SOURCEDIR` to `BUILDDIR` as defined in the Makefile
 * uploading the built html pages as an artifact named `docs-build`, for use in other actions
-  * we can optionally upload the artifact using [artifact.ci](https://github.com/mmkal/artifact.ci) instead, by setting the `use-artifactci` input to `true` (default: `false`). This will upload the artifact to a public URL and allow us to preview the docs. The link to the preview is printed to the GitHub Actions summary.
+  * we can optionally upload the artifact using [artifact.ci](https://github.com/mmkal/artifact.ci) instead, by setting the `use-artifactci` input to `true` (default: `false`). This will upload the artifact to a public URL and allow us to preview the docs. The link to the preview is printed to the GitHub Actions summary. If this is used, the `use-artifactci` input of the [Deploy Sphinx Docs action](../deploy_sphinx_docs/README.md) should also be set to `true`.
 
 It can be run upon all pull requests, to ensure that documentation still builds.
 

--- a/deploy_sphinx_docs/README.md
+++ b/deploy_sphinx_docs/README.md
@@ -11,3 +11,6 @@ The `use-make` input is optional and defaults to `false`.
 As this input helps to identify the location of the built documentation for deployment, it should match the `use-make` value specified in the [Build Sphinx Docs action](../build_sphinx_docs/README.md).
 If set to `true`, it is assumed that the documentation is built using `make` and the `./docs/build/html` directory will be used as the publish directory. 
 If set to `false`, the `./docs/build/` directory will be used instead.
+
+The `use-artifactci` input is optional and defaults to `false`.
+As this input helps to parse the contents of the downloaded artifact, it should match the `use-artifactci` value specified in the [Build Sphinx Docs action](../build_sphinx_docs/README.md).

--- a/deploy_sphinx_docs/action.yml
+++ b/deploy_sphinx_docs/action.yml
@@ -12,6 +12,13 @@ inputs:
     required: false
     type: boolean
     default: false
+  use-artifactci:
+    description: |
+      Specify whether the artifact was uploaded by artifact.ci,
+      to ensure that its contents are moved to the correct publish directory
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: 'composite'
@@ -28,6 +35,15 @@ runs:
     with:
       name: docs-build
       path: ./docs/build
+
+  # If this was downloaded from artifact.ci, the content will be nested
+  # in ./docs/build/docs/build/, so we need to fix that.
+  - name: Move the content to the correct directory
+    if: ${{ inputs.use-artifactci == 'true' }}
+    shell: bash
+    run: |
+      mv ./docs/build/docs/build/* ./docs/build/
+      rm -rf ./docs/build/docs
 
   - name: Deploy
     env: 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

As we discovered yesterday during the `movement v0.8.0` release, when artifact.ci is used to upload the rendered docs (see https://github.com/neuroinformatics-unit/actions/pull/86), sth goes wrong in the subsequent artifact download and deployment in `gh-pages`. This only became apparent when the actual deployment job was run, i.e. only upon release. This resulted in a 1-hour outage for the movement website.

**What does this PR do?**
I diagnosed the issue by using a separate repository, https://github.com/niksirbi/sphinx-deployment-test/, which has the same docs structure as `movement`, and uses the same docs build and deployment workflow.

What I discovered, is that when the artifact is downloaded from artifact.ci (with `./docs/build`) as the target path, its contents end up in a nested `./docs/build/docs/build` subfolder (this is not the case for artifacts uploaded without artifact.ci)

This PR adds an optional `use-artifactci` argument to the Sphinx deployment workflow, to indicate whether the artifact was uploaded with artifact.ci. When this is true, an additional step is activated which extracts the contents from that nested sub-structure into the desired `./docs/build` location (before deployment to `gh-pages`).

## References

https://github.com/neuroinformatics-unit/actions/pull/86
https://github.com/niksirbi/sphinx-deployment-test

## How has this PR been tested?

When deploying https://github.com/niksirbi/sphinx-deployment-test without this fix, the gh-pages branch ended up being empty, with just the `.nojekyll` file, see https://github.com/niksirbi/sphinx-deployment-test/commit/be53567c25cb078716185c2e52f80f0a0ce5ec85

This was true irrespective of artifact.ci mode (lazy or eager).

The deployment was succesful when using this PR's branch as the action source, see:
- [workflow file](https://github.com/niksirbi/sphinx-deployment-test/blob/main/.github/workflows/docs_build_and_deploy.yaml)
- [gh-pages branch contents](https://github.com/niksirbi/sphinx-deployment-test/tree/gh-pages)
- [deployed website](https://nikosirmpilatze.com/sphinx-deployment-test/)

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

The README files have been updated.