### PR TITLE
Add action for multi version deploy of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,10 @@ jobs:
           secret_input: ${{ secrets.GITHUB_TOKEN }}
           use-make: true
           switcher-url: https://<username>.github.io/<repo>/latest/_static/switcher.json
-          base-url: https://<username>.github.io/<repo>
 
 ```
 The `use-make` input is optional as well and defaults to `false`. If set to `true`, the action will assume that the Sphinx documentation is built using `make` and will use the `./docs/build/html` directory as the publish directory. If set to `false`, it will use the `./docs/build/` directory instead. 
 
-The `base-url` is optional and is the URL to be used for initialising the switcher.json file.
 
 ## Full Workflows
 * An example workflow, including linting, testing and release can be found at [example_test_and_deploy.yml](./example_test_and_deploy.yml).

--- a/deploy_sphinx_docs_multiversion/README.md
+++ b/deploy_sphinx_docs_multiversion/README.md
@@ -4,10 +4,11 @@ The docs are then published (by default at `https://<username>.github.io/<repo>/
 
 ## Features
 * Removes any previous builds, if present in `docs/build`
-* Downloads the built html pages (artifact named `docs-build`) into the `docs/build` folder (see the [Build Sphinx Docs action](../build_sphinx_docs/README.md))
+* Downloads the built HTML pages (artifact named `docs-build`) into the docs/build folder (see the [Build Sphinx Docs action](../build_sphinx_docs/README.md))
 * Pushes the built HTML pages to the gh-pages branch under the correct version
 * Updates switcher.json to mark the new version as latest
 * Maintains a latest symlink for convenience
+* Deploys documentation from the main branch as a dev version for ongoing development
 
 ## Inputs
 
@@ -16,7 +17,6 @@ The docs are then published (by default at `https://<username>.github.io/<repo>/
 | `secret_input` | ✅ Yes   | string  | —       | The GitHub token used for authentication. |
 | `switcher-url` | ✅ Yes   | string  | —       | URL of the `switcher.json` file, which will be updated with the new version info. |
 | `use-make`     | ❌ No    | boolean | `false` | Whether the docs were built with `make`. If `true`, deploys from `./docs/build/html`; otherwise from `./docs/build`. |
-| `base-url`    | ❌ No   | string | ""     | The URL to be used as the base-url for the initialising the switcher.json file.   |
 
 > ⚠️ Make sure the value of `use-make` matches what was used in the [Build Sphinx Docs action](../build_sphinx_docs/README.md), otherwise deployment may fail.
 
@@ -45,5 +45,4 @@ jobs:
           secret_input: ${{ secrets.GITHUB_TOKEN }}
           use-make: true
           switcher-url: https://<username>.github.io/<repo>/latest/_static/switcher.json
-          base-url: https://<username>.github.io/<repo>
 ```

--- a/deploy_sphinx_docs_multiversion/action.yml
+++ b/deploy_sphinx_docs_multiversion/action.yml
@@ -16,11 +16,6 @@ inputs:
     description: |
       The URL to the switcher.json file that will be updated with the new version.
     required: true
-  base-url:
-    description: |
-      The URL to be used as the base-url for the initialising the switcher.json file.
-    required: false
-    default: ""
 
 runs:
   using: 'composite'
@@ -68,7 +63,7 @@ runs:
       # Need to have this file so that Github doesn't try to run Jekyll
       touch .nojekyll
 
-      #Add redirection from root url to latest
+      # Add redirection from root url to latest
       echo '<meta http-equiv="Refresh" content="0;url=latest/index.html"/>' > index.html
 
       # Delete all the files and replace with our new  set
@@ -112,13 +107,7 @@ runs:
           echo "${version}/_static/switcher.json has been updated successfully."
         fi
       else
-        # File does not exist, initialize with current version/dev as latest
-        if {{ inputs.base-url }} == "" ]]; then
-          echo "Error: switcher.json does not exist at ${SWITCHER_URL} and no base-url was provided to initialize it."
-          exit 1
-        fi
-        BASE_URL=${{ inputs.base-url }}
-        BASE_URL=${BASE_URL%/}
+        BASE_URL="${SWITCHER_URL%/latest*}"
         NEW_URL="${BASE_URL}/latest"
 
         if [[ "${version}" != "dev" ]]; then
@@ -127,7 +116,7 @@ runs:
             '{name: $name, version: $version, url: $url}')
 
           # Create the "dev" entry
-          DEV_ENTRY=$(jq -n --arg version "dev" --arg url "${BASE_URL}/dev" --arg name "Development" \
+          DEV_ENTRY=$(jq -n --arg version "dev" --arg url "${BASE_URL}/dev" --arg name "dev" \
             '{name: $name, version: $version, url: $url}')
           
           # Combine both


### PR DESCRIPTION
## Description

**What is this PR**
- [x] Addition of a new feature

**Why is this PR needed?**
This PR is the implementation for [Issue-91](https://github.com/neuroinformatics-unit/actions/issues/91). 
At present, our build_sphinx_docs and deploy_sphinx_docs actions only deploy a single version of the documentation (either from main or the latest release) to GitHub Pages. In brief:

build_sphinx_docs builds the Sphinx docs and uploads an artefact
deploy_sphinx_docs downloads the artefact and copies it to the root of the gh-pages branch
This means users and contributors cannot view older versions of the docs, except by checking out an old commit and building locally. Having access to documentation for previous releases would be extremely useful.

**What does this PR do?**
It adds the action `deploy_sphinx_docs_multiversion` which can be used in a GithuB Workflow to push the documents in the `gh-pages` branch as a different directory while maintaining the latest symlink with the latest deployed version for convenience. 
For a complete solution we would have to update the 

## References
A similar implementation is used in the [NeuroBlueprint](https://github.com/neuroinformatics-unit/NeuroBlueprint) repository [here](https://github.com/neuroinformatics-unit/NeuroBlueprint/blob/main/.github/workflows/docs_build_and_deploy.yml). 

## How has this PR been tested?
A test implementation exists by forking [this repository](https://github.com/neuroinformatics-unit/sphinx-deployment-test) and making [changes](https://github.com/neuroinformatics-unit/sphinx-deployment-test/compare/main...animeshsasan:sphinx-deployment-test:main) to enable the multi-version switcher. You can see it in action [here](https://animeshsasan.github.io/sphinx-deployment-test/latest/index.html).

The PR also adds a new action instead of updating a current one. Therefore, no current functionality has changed.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

It requires updating the movement repository to create the multi-version dropdown but no actual documentation has changed.

## Checklist:

- [x] The code has been tested locally
- [ ] ~~Tests have been added to cover all new functionality~~(I don't think there are any tests for actions)
- [ ] ~~The documentation has been updated to reflect any changes~~
- [ ] ~~The code has been formatted with [pre-commit](https://pre-commit.com/)~~(I don't think this repo has a `pre-commit.yaml` file)
