### PR TITLE
Fetch switcher.json content from latest for `dev` builds

### DIFF
--- a/deploy_sphinx_docs_multiversion/action.yml
+++ b/deploy_sphinx_docs_multiversion/action.yml
@@ -101,13 +101,10 @@ runs:
 
           # Combine the entries in the desired order
           SWITCHER_CONTENT=$(jq --argjson dev_entry "$DEV_ENTRY" --argjson new_entry "$NEW_ENTRY" --argjson updated_current_latest "$UPDATED_CURRENT_LATEST_ENTRY" '[$dev_entry, $new_entry, $updated_current_latest] + .[2:]' <<< "$SWITCHER_CONTENT")
-          echo "${version}/_static/switcher.json has been updated successfully."
-        fi
-        elif [[ "${version}" == "dev" ]]; then
-          echo -e "\nNo need to update switcher.json at ${SWITCHER_URL}, using latest."
         fi
         SWITCHER_FILE="${version}/_static/switcher.json"
         echo "SWITCHER_CONTENT" > "$SWITCHER_FILE"
+        echo "${version}/_static/switcher.json has been updated successfully."
       else
         BASE_URL="${SWITCHER_URL%/latest*}"
         NEW_URL="${BASE_URL}/latest"


### PR DESCRIPTION
Currently, if a file exists at `inputs.switcher-url` and it's a dev deployment, the `switcher.json` content is not fetched from latest, and ends up falling back to a `docs/build/html/_static/switcher.json` that exists in the repo, which may be out of date.

This PR makes sure that if a file exists at `inputs.switcher-url` then it's fetched regardless if it's a `dev` or version deployment.