### PR TITLE
Remove trailing slashes for safer cleaning of BASE_URL

### DIFF
--- a/deploy_sphinx_docs_multiversion/action.yml
+++ b/deploy_sphinx_docs_multiversion/action.yml
@@ -86,7 +86,7 @@ runs:
         SWITCHER_CONTENT=$(curl "$SWITCHER_URL")
         if [[ "${version}" != "dev" ]]; then
           echo -e "\nUpdating switcher.json at ${SWITCHER_URL} for version ${version}."
-          BASE_URL="$(jq -r '.[1].url|split("/")[0:-1]|join("/")' <<< $SWITCHER_CONTENT)"
+          BASE_URL="$(jq -r '.[1].url | sub("/+$"; "") | split("/")[:-1] | join("/")' <<< "$SWITCHER_CONTENT")"
           NEW_URL="${BASE_URL}/latest"
 
           # Extract the current dev entry


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
As suggested by @niksirbi there is an issue in dealing with trailing slashes while getting the `BASE_URL` from the `SWITCHER_CONTENT`:

> The problem actually comes from this line of the action
> 
> `BASE_URL="$(jq -r '.[1].url|split("/")[0:-1]|join("/")' <<< $SWITCHER_CONTENT)"`
> which is supposed to remove the last element of the URL (after the last slash). This is not robust to trailing slashes, and one such trailing slash was [present in the URL of version v0.3.3](https://github.com/neuroinformatics-unit/NeuroBlueprint/blob/ac777cdae1c485b9138982283797103eb6f0cde1/v0.3.3/_static/switcher.json#L9).
> 
> This edge case arose specifically in NeurBlueprint, because our previous hacky workflow was appending /latest/ to the new URL. I don't think we would have encountered this in movement, but in any case we should harden the implementation against such slash mishaps.

**What does this PR do?**
Implements a fix to the above issue by removing any trailing slashes while getting the `BASE_URL`.

## References

https://github.com/neuroinformatics-unit/movement/pull/668#issuecomment-3338644656

## How has this PR been tested?

Tested in [this repo](https://github.com/animeshsasan/sphinx-deployment-test) by manually pushing a trailing slash in the [switcher.json](https://animeshsasan.github.io/sphinx-deployment-test/latest/_static/switcher.json) in the latest. Deploying the new version is able to handle the trailing slash.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
