### PR TITLE
Optionally use pyproject.toml for docs dependencies

### DIFF
--- a/build_sphinx_docs/README.md
+++ b/build_sphinx_docs/README.md
@@ -7,8 +7,8 @@ The various steps include:
   * the version can be specified via the `python-version` input, and defaults to `3.x`
 * installing pip and setting up pip cache
 * pip installing build dependencies (themes, build tools, etc.) in one of two ways:
-  * by default, from `docs/requirements.txt` (with `use-requirementstxt: true`), or
-  * from the `[docs]` section of `pyproject.toml` (with `use-requirementstxt: false`) 
+  * by default, from `docs/requirements.txt` (with `use-requirements-txt: true`), or
+  * from the `[docs]` section of `pyproject.toml` (with `use-requirements-txt: false`) 
 * checking that external links in the documentation are not broken 
   * optional, defaults to `true` (i.e. links are checked), see the [warning](#warning) below for more information
 * building the html pages in one of two ways, by setting the `use-make` input (default: `false`)

--- a/build_sphinx_docs/action.yml
+++ b/build_sphinx_docs/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     type: boolean
     default: false
-  use-requirementstxt:
+  use-requirements-txt:
     description: 'Use `docs/requirements.txt` for the docs dependencies. "false" uses [docs] optional dependencies from pyproject.toml'
     required: false
     type: boolean
@@ -64,14 +64,14 @@ runs:
     uses: actions/cache@v4
     with:
       path: ${{ steps.pip-cache.outputs.dir }}
-      key: ${{ runner.os }}-pip-${{ inputs.use-requirementstxt == 'true' && hashFiles('**/requirements.txt') || hashFiles('**/pyproject.toml') }}
+      key: ${{ runner.os }}-pip-${{ inputs.use-requirements-txt == 'true' && hashFiles('**/requirements.txt') || hashFiles('**/pyproject.toml') }}
       restore-keys: |
         ${{ runner.os }}-pip-
 
   - name: Install dependencies
     shell: bash
     run: |
-      if [ ${{ inputs.use-requirementstxt }} == 'true' ]; then
+      if [ ${{ inputs.use-requirements-txt }} == 'true' ]; then
         python3 -m pip install -r ./docs/requirements.txt
       else
         python3 -m pip install ".[docs]"


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
To support building docs in CI when the doc dependencies are specified as extras in pyproject.toml.

**What does this PR do?**
Adds a user input to the sphinx doc building action that defines where the doc requirements are defined.

Note that the cache behaviour uses `hashFiles('**/pyproject.toml')` which can be overly restrictive because pyproject.toml contains much more than just the docs dependencies. But reinstalling the docs dependencies a bit more often than necessary should not be too demanding since they are relatively lightweight. 

## References

Inspired by https://github.com/neuroinformatics-unit/poseinterface/pull/4

## How has this PR been tested?

We tested this on `poseinterface` in PR https://github.com/neuroinformatics-unit/poseinterface/pull/6.
The CI passes with both boolean values of `use-requirements-txt`.

See succesful CI runs for:
-  [x] `use-requirements-txt: false`: https://github.com/neuroinformatics-unit/poseinterface/actions/runs/20309965109?pr=6
- [x] `use-requirements-txt: true`: https://github.com/neuroinformatics-unit/poseinterface/actions/runs/20310157776?pr=7

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?
Included.

## Checklist:

- [ ] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
