### PR TITLE
Use tox-uv in test action

### DIFF
--- a/test/action.yml
+++ b/test/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox tox-gh-actions
+        python -m pip install tox tox-gh-actions tox-uv
 
     - name: Run tests
       if: ${{ !matrix.use-xvfb }}


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Closes #117

This became urgent now, because `tox` was having trouble resolving dependencies in `movement` CI (see https://github.com/neuroinformatics-unit/movement/issues/762) and we hypothesised that `tox-uv` would circumvent those issues.

**What does this PR do?**

The test action now installs [`tox-uv`](https://github.com/tox-dev/tox-uv) alongside `tox` and `tox-gh-actions`. Afaik, this should be all we need to do.

## References

- Closes #117 
- Motivated by https://github.com/neuroinformatics-unit/movement/pull/762
- Tested in https://github.com/neuroinformatics-unit/movement/pull/766

## How has this PR been tested?

I've tried it in https://github.com/neuroinformatics-unit/movement/pull/766, where I temporarily pointed `movement`'s CI to the `tox-uv` branch of `actions` (i.e the branch of this PR).

__Good news:__ this seems to solve https://github.com/neuroinformatics-unit/movement/issues/762, proving that dependency resolution indeed proceeds differently with `tox-uv`.

I don't see much speed up in the runtime of CI though... It could be because dependency resolution (which is what `tox-uv` speeds up), is anyway a small fraction of the total time it takes to run tests.

## Is this a breaking change?

This is a drop-in replacement. Consuming repos should automatically benefit from `uv`'s faster package installation without any changes to their tox configuration.

To be on the safe side, I won't immediately make a new `actions` release after merging this PR. 

Most of our projects should be using the v2 version of our actions. If they want to dip their toes into the water, they may try using the test action from the `main` branch, and if that successfully works across some projects, we can make a new actions release then. @IgorTatarnikov I would be interested in knowing if this breaks anything on the BrainGlobe side of things.

If some projects are already depending on the `main` branch, they may observe changes in dependency resolution right away. If something breaks for them, they can fall back to `actions@v2` while we investigate.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
