### PR TITLE
Fix root-level 404 handling in multiversion Sphinx docs deployment

### DIFF
--- a/deploy_sphinx_docs_multiversion/action.yml
+++ b/deploy_sphinx_docs_multiversion/action.yml
@@ -79,6 +79,11 @@ runs:
       
       cp -Rvf $BUILD_DIR ${version}/
 
+      if [ -f "${version}/404.html" ]; then
+        echo -e "\nUpdating root-level 404.html from ${version}/404.html"
+        cp -f "${version}/404.html" 404.html
+      fi
+
       SWITCHER_URL="${{ inputs.switcher-url }}"
       
       if curl --output /dev/null --silent --head --fail "$SWITCHER_URL"; then


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
- GitHub Pages only serves ```404.html``` from the root of the ```gh-pages``` branch. While each documentation version correctly generates its own ```404.html```, the root-level file was not being updated during deployment.

**What does this PR do?**
- It updates the ```deploy_sphinx_docs_multiversion``` action to copy the built version’s ```404.html``` file to the root of the ```gh-pages``` branch during deployment.

## References
- Fixes #144.

## How has this PR been tested?
- Verified that the copy operation runs only if the versioned ```404.html``` exists.

## Is this a breaking change?
- No.

## Does this PR require an update to the documentation?
- No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
