### PR TITLE
Use latest 404.html in multiversion Sphinx docs deployment

### DIFF
--- a/deploy_sphinx_docs_multiversion/action.yml
+++ b/deploy_sphinx_docs_multiversion/action.yml
@@ -79,7 +79,7 @@ runs:
       
       cp -Rvf $BUILD_DIR ${version}/
 
-      if [ -f "${version}/404.html" ]; then
+      if [[ "${version}" != "dev" && -f "${version}/404.html" ]]; then
         echo -e "\nUpdating root-level 404.html from ${version}/404.html"
         cp -f "${version}/404.html" 404.html
       fi

--- a/deploy_sphinx_docs_multiversion/action.yml
+++ b/deploy_sphinx_docs_multiversion/action.yml
@@ -80,7 +80,7 @@ runs:
       cp -Rvf $BUILD_DIR ${version}/
 
       if [[ "${version}" != "dev" && -f "${version}/404.html" ]]; then
-        echo -e "\nUpdating root-level 404.html from ${version}/404.html"
+        echo -e "\nUpdating root-level 404.html with ${version}/404.html"
         cp -f "${version}/404.html" 404.html
       fi
 

--- a/deploy_sphinx_docs_multiversion/action.yml
+++ b/deploy_sphinx_docs_multiversion/action.yml
@@ -79,6 +79,11 @@ runs:
       
       cp -Rvf $BUILD_DIR ${version}/
 
+      if [ -f "${version}/404.html" ]; then
+        echo -e "\nUpdating root-level 404.html from ${version}/404.html"
+        cp -f "${version}/404.html" 404.html
+      fi
+
       SWITCHER_URL="${{ inputs.switcher-url }}"
       
       if curl --output /dev/null --silent --head --fail "$SWITCHER_URL"; then


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
closes #144 

**What does this PR do?**
This PR supersedes #149 and replaces the root-level 404.html (which GH pages redirects to from pages not found) with the non-dev version (usually the latest) that triggered the deployment

## How has this PR been tested?
Tested in the NIU sphinx-deployment-test repo (e.g. https://neuroinformatics.dev/sphinx-deployment-test/latest/in redirects to a styled 404.html)
Log message indicating the root level 404.html is being replaced: https://github.com/neuroinformatics-unit/sphinx-deployment-test/actions/runs/24352500814/job/71110623204#step:2:412

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
