### PR TITLE
Use `docs` group dependency from pyproject.toml in build_docs action

### DIFF
--- a/build_sphinx_docs/README.md
+++ b/build_sphinx_docs/README.md
@@ -8,7 +8,7 @@ The various steps include:
 * installing pip and setting up pip cache
 * pip installing build dependencies (themes, build tools, etc.) in one of two ways:
   * by default, from `docs/requirements.txt` (with `use-requirements-txt: true`), or
-  * from the `[docs]` section of `pyproject.toml` (with `use-requirements-txt: false`) 
+  * from the `docs` [dependency group](https://packaging.python.org/en/latest/specifications/dependency-groups/#dependency-groups) in `pyproject.toml` (with `use-requirements-txt: false`) 
 * checking that external links in the documentation are not broken
   * optional, defaults to `true` (i.e. links are checked), see the [warning](#warning) below for more information
   * you can pass a GitHub token via the `github-token` input, which is exposed as the `GITHUB_TOKEN` environment variable during linkcheck. This can help avoid rate-limiting when checking links to GitHub repositories.

--- a/build_sphinx_docs/action.yml
+++ b/build_sphinx_docs/action.yml
@@ -28,7 +28,7 @@ inputs:
     type: boolean
     default: false
   use-requirements-txt:
-    description: 'Use `docs/requirements.txt` for the docs dependencies. "false" uses [docs] optional dependencies from pyproject.toml'
+    description: 'Use `docs/requirements.txt` for the docs dependencies. "false" uses the `docs` dependency group from pyproject.toml'
     required: false
     type: boolean
     default: true
@@ -79,7 +79,7 @@ runs:
       if [ ${{ inputs.use-requirements-txt }} == 'true' ]; then
         python3 -m pip install -r ./docs/requirements.txt
       else
-        python3 -m pip install ".[docs]"
+        python3 -m pip install . --group docs
       fi
 
   - name: Check links


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
This PR is needed as part of the work for migrating `docs` from optional dependencies to PEP 735 dependency groups (in https://github.com/neuroinformatics-unit/movement/pull/956)
Details are described in the issue: https://github.com/neuroinformatics-unit/movement/issues/955

**What does this PR do?**
Updates the pip install command to use `--group`

## How has this PR been tested?
This is tested in https://github.com/neuroinformatics-unit/movement/pull/956 CI 
- build docs@main [fails](https://github.com/neuroinformatics-unit/movement/actions/runs/24256424665/job/70829024250?pr=956) because of this issue.
- build docs@build-docs-group-dep [passes](https://github.com/neuroinformatics-unit/movement/actions/runs/24355193043/job/71120187411?pr=956)
## Is this a breaking change?
Docs build in existing repos using the pyproject.toml option will fail ([movement example](https://github.com/neuroinformatics-unit/movement/actions/runs/24256424665/job/70829024250?pr=956))

## Does this PR require an update to the documentation?
Yes

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
