### PR TITLE
Fall back to `.[docs]` extras if `--group docs` fails

### DIFF
--- a/build_sphinx_docs/action.yml
+++ b/build_sphinx_docs/action.yml
@@ -79,7 +79,13 @@ runs:
       if [ ${{ inputs.use-requirements-txt }} == 'true' ]; then
         python3 -m pip install -r ./docs/requirements.txt
       else
-        python3 -m pip install . --group docs
+        if ! python3 -m pip install . --group docs; then
+          msg="Failed to install using 'docs' dependency group."
+          msg="$msg Consider migrating from optional-dependencies"
+          msg="$msg to PEP 735 dependency-groups in pyproject.toml."
+          echo "::warning::$msg"
+          python3 -m pip install ".[docs]"
+        fi
       fi
 
   - name: Check links

--- a/build_sphinx_docs/action.yml
+++ b/build_sphinx_docs/action.yml
@@ -80,7 +80,8 @@ runs:
         python3 -m pip install -r ./docs/requirements.txt
       else
         if ! python3 -m pip install . --group docs; then
-          msg="Failed to install using 'docs' dependency group."
+          msg="Failed to install using 'docs' dependency group;"
+          msg="$msg falling back to '.[docs]' extras."
           msg="$msg Consider migrating from optional-dependencies"
           msg="$msg to PEP 735 dependency-groups in pyproject.toml."
           echo "::warning::$msg"


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
#158  introduces a breaking change in that existing `build_sphinx_docs` users (e.g. [neuroinformatics-unit/poseinterface](https://github.com/neuroinformatics-unit/poseinterface/blob/abb95bf26576bc840f8d0090d085b17b170a9da3/.github/workflows/docs_build_and_deploy.yml#L33), [brainglobe/brainglobe-data-api-connectivity](https://github.com/brainglobe/brainglobe-data-api-connectivity/blob/8f8606d0d0678baab994cafa19ca3bb712769da8/.github/workflows/docs_build_and_deploy.yml#L32)) who 
- configured `use-requirements-txt: false` and 
- still have `docs` dependencies under `[project.optional-dependencies]` in pyproject.toml

will run into action failures
- if they are using `build_sphinx_docs@main` or
- when they upgrade to `build_sphinx_docs@v3`

**What does this PR do?**
This PR provides a fallback to using `.[docs]` extras if `--group docs` fails. It also issues a warning and recommends migrating to PEP 735 dependency-groups in pyproject.toml.

## References
#158 

## How has this PR been tested?
Tested in https://github.com/neuroinformatics-unit/poseinterface/pull/47 (see [warning message emitted in Build sphinx docs](https://github.com/neuroinformatics-unit/poseinterface/actions/runs/25007576544?pr=47))

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
