### PR TITLE
Add experimental test-uv reusable action

### DIFF
--- a/test-uv/action.yml
+++ b/test-uv/action.yml
@@ -1,0 +1,84 @@
+name: 'Python test'
+description: 'Run Python tests using uv'
+
+inputs:
+  python-version:
+    description: 'Python version'
+    required: true
+    type: string
+  pytest-args:
+    description: 'Arguments to pass to the pytest command'
+    required: false
+    type: string
+    default: ''
+  install-extras:
+    description: 'Comma-separated extras to install'
+    required: false
+    type: string
+    default: 'dev'
+  extra-dependencies:
+    description: 'Space-separated packages to install on top of the main install'
+    required: false
+    type: string
+    default: ''
+  use-xvfb:
+    description: 'Run tests with XVFB on Linux'
+    required: false
+    type: boolean
+    default: false
+  codecov-flags:
+    description: 'Flags to pass to codecov'
+    required: false
+    type: string
+    default: ''
+  secret-codecov-token:
+    description: 'Codecov token to upload coverage reports'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v6
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install package and dependencies
+      shell: bash
+      env:
+        EXTRAS: ${{ inputs.install-extras }}
+      run: uv pip install -e ".[$EXTRAS]" --system
+
+    - name: Install extra dependencies
+      if: ${{ inputs.extra-dependencies != '' }}
+      shell: bash
+      run: uv pip install ${{ inputs.extra-dependencies }} --system
+
+    - name: Run tests
+      if: ${{ inputs.use-xvfb != 'true' }}
+      shell: bash
+      run: uv run pytest ${{ inputs.pytest-args }}
+
+    - name: Run tests with XVFB
+      if: ${{ inputs.use-xvfb == 'true' }}
+      # SHA corresponds to v1.1 release
+      uses: aganders3/headless-gui@f85dd6316993505dfc5f21839d520ae440c84816
+      with:
+        run: uv run pytest ${{ inputs.pytest-args }}
+
+    - name: Issue deprecation warning for tokenless codecov
+      shell: bash
+      run: |
+        if [[ -z "${{ inputs.secret-codecov-token }}" ]]; then
+          echo '::warning::secret-codecov-token is not set. This will be required in the future.'\
+          ' See https://docs.codecov.com/docs/quick-start#step-2-get-the-repository-upload-token on how to get a token.'
+        fi
+
+    - name: Report coverage to codecov
+      uses: codecov/codecov-action@v6
+      with:
+        flags: ${{ inputs.codecov-flags }}
+        token: ${{ inputs.secret-codecov-token }}

--- a/test-uv/action.yml
+++ b/test-uv/action.yml
@@ -50,12 +50,12 @@ runs:
       shell: bash
       env:
         EXTRAS: ${{ inputs.install-extras }}
-      run: uv pip install -e ".[$EXTRAS]" --system
+      run: uv pip install -e ".[$EXTRAS]"
 
     - name: Install extra dependencies
       if: ${{ inputs.extra-dependencies != '' }}
       shell: bash
-      run: uv pip install ${{ inputs.extra-dependencies }} --system
+      run: uv pip install ${{ inputs.extra-dependencies }}
 
     - name: Run tests
       if: ${{ inputs.use-xvfb != 'true' }}

--- a/test-uv/action.yml
+++ b/test-uv/action.yml
@@ -38,10 +38,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
         python-version: ${{ inputs.python-version }}
@@ -66,8 +66,7 @@ runs:
 
     - name: Run tests with XVFB
       if: ${{ inputs.use-xvfb == 'true' }}
-      # SHA corresponds to v1.1 release
-      uses: aganders3/headless-gui@f85dd6316993505dfc5f21839d520ae440c84816
+      uses: aganders3/headless-gui@f85dd6316993505dfc5f21839d520ae440c84816 # v2.2
       with:
         run: pytest ${{ inputs.pytest-args }}
 
@@ -80,7 +79,7 @@ runs:
         fi
 
     - name: Report coverage to codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         flags: ${{ inputs.codecov-flags }}
         token: ${{ inputs.secret-codecov-token }}

--- a/test-uv/action.yml
+++ b/test-uv/action.yml
@@ -45,29 +45,31 @@ runs:
       with:
         enable-cache: true
         python-version: ${{ inputs.python-version }}
+        cache-dependency-glob: "**/pyproject.toml"
 
     - name: Install package and dependencies
       shell: bash
       env:
         EXTRAS: ${{ inputs.install-extras }}
-      run: uv pip install -e ".[$EXTRAS]"
-
-    - name: Install extra dependencies
-      if: ${{ inputs.extra-dependencies != '' }}
-      shell: bash
-      run: uv pip install ${{ inputs.extra-dependencies }}
+        EXTRA_DEPS: ${{ inputs.extra-dependencies }}
+      run: |
+        if [[ -n "$EXTRA_DEPS" ]]; then
+          uv pip install -e ".[$EXTRAS]" $EXTRA_DEPS
+        else
+          uv pip install -e ".[$EXTRAS]"
+        fi
 
     - name: Run tests
       if: ${{ inputs.use-xvfb != 'true' }}
       shell: bash
-      run: uv run pytest ${{ inputs.pytest-args }}
+      run: pytest ${{ inputs.pytest-args }}
 
     - name: Run tests with XVFB
       if: ${{ inputs.use-xvfb == 'true' }}
       # SHA corresponds to v1.1 release
       uses: aganders3/headless-gui@f85dd6316993505dfc5f21839d520ae440c84816
       with:
-        run: uv run pytest ${{ inputs.pytest-args }}
+        run: pytest ${{ inputs.pytest-args }}
 
     - name: Issue deprecation warning for tokenless codecov
       shell: bash


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
- As part of the CI modernisation investigation, this PR introduces an experimental uv-based testing action that can be evaluated as an alternative to the existing tox-based test action.

**What does this PR do?**
- Adds a new reusable ```test-uv``` GitHub Action.

## References
- **Issue-**[93](https://github.com/brainglobe/BrainGlobe/issues/93)

## Is this a breaking change?
- No.

## Does this PR require an update to the documentation?
- No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
