### PR TITLE
Update headless setup and install input

### DIFF
--- a/test-uv/action.yml
+++ b/test-uv/action.yml
@@ -22,7 +22,7 @@ inputs:
     type: string
     default: ''
   install-main-branch:
-    description: 'GitHub repo to install from main branch'
+    description: 'Comma-separated GitHub repo to install from main branch'
     required: false
     type: string
     default: ''
@@ -53,6 +53,17 @@ runs:
         cache-dependency-glob: "**/pyproject.toml"
         activate-environment: true
 
+    - name: Install main branch dependencies
+      if: ${{ inputs.install-main-branch != '' }}
+      shell: bash
+      env:
+        MAIN_BRANCH_DEPS: ${{ inputs.install-main-branch }}
+      run: |
+        IFS=',' read -ra repos <<< "$MAIN_BRANCH_DEPS"
+        for repo in "${repos[@]}"; do
+          uv pip install "git+https://github.com/${repo// /}"
+        done
+
     - name: Install package and dependencies
       shell: bash
       env:
@@ -64,13 +75,6 @@ runs:
         else
           uv pip install -e ".[$EXTRAS]"
         fi
-      
-    - name: Install main branch dependency
-      if: ${{ inputs.install-main-branch != '' }}
-      shell: bash
-      env:
-        MAIN_BRANCH_DEP: ${{ inputs.install-main-branch }}
-      run: uv pip install "git+https://github.com/$MAIN_BRANCH_DEP"
 
     - name: Set up headless display
       if: ${{ inputs.use-headless == 'true' }}

--- a/test-uv/action.yml
+++ b/test-uv/action.yml
@@ -22,7 +22,7 @@ inputs:
     type: string
     default: ''
   install-main-branch:
-    description: 'Comma-separated GitHub repo to install from main branch'
+    description: 'Comma-separated list of GitHub repos to install from main branch'
     required: false
     type: string
     default: ''

--- a/test-uv/action.yml
+++ b/test-uv/action.yml
@@ -21,8 +21,13 @@ inputs:
     required: false
     type: string
     default: ''
-  use-xvfb:
-    description: 'Run tests with XVFB on Linux'
+  install-main-branch:
+    description: 'GitHub repo to install from main branch'
+    required: false
+    type: string
+    default: ''
+  use-headless:
+    description: 'Run tests with pyvista headless display'
     required: false
     type: boolean
     default: false
@@ -59,17 +64,21 @@ runs:
         else
           uv pip install -e ".[$EXTRAS]"
         fi
+      
+    - name: Install main branch dependency
+      if: ${{ inputs.install-main-branch != '' }}
+      shell: bash
+      env:
+        MAIN_BRANCH_DEP: ${{ inputs.install-main-branch }}
+      run: uv pip install "git+https://github.com/$MAIN_BRANCH_DEP"
+
+    - name: Set up headless display
+      if: ${{ inputs.use-headless == 'true' }}
+      uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4
 
     - name: Run tests
-      if: ${{ inputs.use-xvfb != 'true' }}
       shell: bash
       run: pytest ${{ inputs.pytest-args }}
-
-    - name: Run tests with XVFB
-      if: ${{ inputs.use-xvfb == 'true' }}
-      uses: aganders3/headless-gui@f85dd6316993505dfc5f21839d520ae440c84816 # v2.2
-      with:
-        run: pytest ${{ inputs.pytest-args }}
 
     - name: Issue deprecation warning for tokenless codecov
       shell: bash

--- a/test-uv/action.yml
+++ b/test-uv/action.yml
@@ -79,6 +79,8 @@ runs:
     - name: Set up headless display
       if: ${{ inputs.use-headless == 'true' }}
       uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4
+      with:
+        qt: true
 
     - name: Run tests
       shell: bash


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
- `aganders3/headless-gui` hasn't been updated for long and the napari-dev scheduled test required manual steps in every calling workflow.

**What does this PR do?**
- Replaces `aganders3/headless-gui` with `pyvista/setup-headless-display-action@v4` via a new `use-headless` input.
- Adds `install-main-branch` input that installs a dependency from its main branch into the same uv venv.

## References
- Closes #178, #179 

## Is this a breaking change?
- No.

## Does this PR require an update to the documentation?
- No.

## Checklist:

- [ ] The code has been tested locally
- [ n/a] Tests have been added to cover all new functionality
- [ n/a] The documentation has been updated to reflect any changes
- [ n/a] The code has been formatted with [pre-commit](https://pre-commit.com/)
